### PR TITLE
Rebase to master + default gitlab to https

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,11 +98,19 @@ git-open can automatically guess the corresponding repository page for remotes
 
 #### GitLab support
 
-To configure GitLab support you need to set `gitopen.gitlab.domain`:
+To configure GitLab support you need to set some options.
+
+| option name               | description                                                | example            |
+| ------------------------- | ---------------------------------------------------------- | ------------------ |
+| gitopen.gitlab.domain     | The (web)domain name that will work for most of the people | gitlab.example.com |
+| gitopen.gitlab.ssh.domain | A specific ssh domain name, *if needed*                    | git.example.com    |
+| gitopen.gitlab.ssh.port   | A specific ssh port, *if needed*                           | 10022              |
 
 ```sh
 # use --global to set across all repos, instead of just the local one
-git config [--global] gitopen.gitlab.domain [yourdomain.here]
+git config [--global] gitopen.gitlab.domain [value]
+git config [--global] gitopen.gitlab.ssh.domain [value]
+git config [--global] gitopen.gitlab.ssh.port [value]
 ```
 
 If your Gitlab custom hosted is serving `http` you can also specify this:

--- a/git-open
+++ b/git-open
@@ -92,26 +92,30 @@ elif grep -q "/scm/" <<<$giturl; then
 else
   # custom GitLab
   gitlab_domain=$(git config --get gitopen.gitlab.domain)
-  gitlab_port=$(git config --get gitopen.gitlab.port)
+  gitlab_ssh_domain=$(git config --get gitopen.gitlab.ssh.domain)
+  gitlab_ssh_domain=${gitlab_ssh_domain:-$gitlab_domain}
+  gitlab_ssh_port=$(git config --get gitopen.gitlab.ssh.port)
+  
   gitlab_protocol=$(git config --get gitopen.gitlab.protocol)
   if [ -z "$gitlab_protocol" ]; then
       gitlab_protocol=http
   fi
-  if [ -n "$gitlab_domain" ]; then
-    if grep -q "$gitlab_domain" <<<$giturl; then
+
+if [ -n "$gitlab_domain" ]; then
+    if egrep -q "${gitlab_domain}|${gitlab_ssh_domain}" <<<$giturl; then
 
       # Handle GitLab's default SSH notation (like git@gitlab.domain.com:user/repo)
-      giturl=${giturl/git\@${gitlab_domain}\:/${gitlab_protocol}://${gitlab_domain}/}
+      giturl=${giturl/git\@${gitlab_ssh_domain}\:/${gitlab_protocol}://${gitlab_domain}/}
 
       # handle SSH protocol (links like ssh://git@gitlab.domain.com/user/repo)
       giturl=${giturl/#ssh\:\/\//${gitlab_protocol}://}
 
       # remove git@ from the domain
-      giturl=${giturl/git\@${gitlab_domain}/${gitlab_domain}/}
+      giturl=${giturl/git\@${gitlab_ssh_domain}/${gitlab_domain}/}
 
       # remove SSH port
-      if [ -n "$gitlab_port" ]; then
-        giturl=${giturl/\/:${gitlab_port}\///}
+      if [ -n "$gitlab_ssh_port" ]; then
+        giturl=${giturl/\/:${gitlab_ssh_port}\///}
       fi
       providerUrlDifference=tree
     fi

--- a/git-open
+++ b/git-open
@@ -98,7 +98,7 @@ else
   
   gitlab_protocol=$(git config --get gitopen.gitlab.protocol)
   if [ -z "$gitlab_protocol" ]; then
-      gitlab_protocol=http
+      gitlab_protocol=https
   fi
 
 if [ -n "$gitlab_domain" ]; then

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "git-open",
-  "version": "1.1.1",
+  "version": "1.2.0",
   "description": "Type `git open` to open the GitHub/GitLab/Bitbucket homepage for a repository.",
   "author": "Paul Irish (http://paulirish.com/)",
   "license": "MIT",


### PR DESCRIPTION
Okay there two separate commits here tackle two things:

1. rebase your branch to master, resolving the conflict with https://github.com/paulirish/git-open/pull/56 (as that was merged first)
1. if `gitlab.protocol` isn't set, default it to https. 

The second seems slightly contentious so here's my reasoning.

HTTP for source control seems bad. However I can imagine smaller shops that have their own self-hosted gitlab that is firewalled, and getting a certificate is still extra work... soo..  
Anyway, I think users should have to opt-in to http. They are already specifying a bunch of config for their gitlab setup anyway, so also doing the protocol seems fine.

does this work for you?
cc @ffes


---

(note this PR is on the MartinDelille repo. but once merged, it'll be in the https://github.com/paulirish/git-open/pull/60 PR, and i'll merge (after squashing) that.)